### PR TITLE
Issue-2: Add initial support for Either

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 * [`data`](./data)
+    * [`Either`](./data/Either/)
     * [`Functions`](./data/Functions/)
     * [`Maybe`](./data/Maybe)
     * [`Tuple`](./data/Tuple)

--- a/docs/data/Either/Either.md
+++ b/docs/data/Either/Either.md
@@ -1,0 +1,38 @@
+# `Either<A, B>`
+
+## Types
+
+* `A`: The underlying left type.
+* `B`: The underlying right type.
+
+## Constructors
+
+* [`Either<L, R> left(L value)`][left]
+* [`Either<L, R> right(R value)`][right]
+
+## Static Methods
+
+* [`Function<Function<R, C>, Function<Either<L, R>, C>> eitherMap(Function<L, C>)`][eitherMap]
+* [`Function<Either<L, R>, C> eitherMap(Function<L, C>, Function<R, C>)`][eitherMap]
+* [`C eitherMap(Function<L, C>, Function<R, C>, Either<L, R>)`][eitherMap]
+* [`Function<Either<L, R>, L> fromLeft(L defaultValue)`][fromLeft]
+* [`L fromLeft(L defaultValue, Either<L, R> either)`][fromLeft]
+* [`Function<Either<L, R>, R> fromRight(R defaultValue)`][fromRight]
+* [`R fromRight(R defaultValue, Either<L, R> either)`][fromRight]
+* [`Collection<L> lefts(Collection<Either<L, R>> collection)`][lefts]
+* [`Tuple<Collection<L>, Collection<R>> partitionEithers(Collection<Either<L, R>> collection)`][partitionEithers]
+* [`Collection<R> rights(Collection<Either<L, R>> collection)`][rights]
+
+## Instance Methods
+
+* `boolean isLeft()`: Determines whether or not the `Either` is a `Left`.
+* `boolean isRight()`: Determines whether or not the `Either` is a `Right`.
+
+[eitherMap]: ./static/eitherMap.md
+[fromLeft]: ./static/fromLeft.md
+[fromRight]: ./static/fromRight.md
+[left]: ./constructors/left.md
+[lefts]: ./static/lefts.md
+[partitionEithers]: ./static/partitionEithers.md
+[right]: ./constructors/right.md
+[rights]: ./static/rights.md

--- a/docs/data/Either/README.md
+++ b/docs/data/Either/README.md
@@ -1,0 +1,21 @@
+# `Either`
+
+The `Either` type is a right-biased disjunction that represents two possibilities: either a `Left` of `a` or a `Right` of `b`. By convention, the `Either` is used to represent a value or an error result of some function or process as a `Left` of the error or a `Right` of the value.
+
+* [Interface](./Either.md)
+* [Constructors](./constructors)
+    * [`.left`](./constructors/left.md)
+    * [`.right`](./constructors/right.md)
+* [Static Methods](./static)
+    * [`.eitherMap`](./static/eitherMap.md)
+    * [`.fromLeft`](./static/fromLeft.md)
+    * [`.fromRight`](./static/fromRight.md)
+    * [`.lefts`](./static/lefts.md)
+    * [`.partitionEithers`](./static/partitionEithers.md)
+    * [`.rights`](./static/rights.md)
+* [Instance Methods](./instance)
+    * [`#equals`](./instance/equals.md)
+    * [`#isLeft`](./instance/isLeft.md)
+    * [`#isRight`](./instance/isRight.md)
+    * [`#toJSON`](./instance/toJSON.md)
+    * [`#toString`](./instance/toString.md)

--- a/docs/data/Either/constructors/README.md
+++ b/docs/data/Either/constructors/README.md
@@ -1,0 +1,6 @@
+# Either Constructors
+
+## Table of Contents
+
+* [`.left`](./left.md)
+* [`.right`](./right.md)

--- a/docs/data/Either/constructors/left.md
+++ b/docs/data/Either/constructors/left.md
@@ -1,0 +1,23 @@
+# `Either.<L, R>left(L value)`
+
+Encapsulates a left value.
+
+## Arguments
+
+* `value (L)`: A value.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(Either<L, R>)`: An `Either` of the `value`.
+
+## Example
+
+```java
+Either.<Integer, String>left(0);
+// => Left(0)
+```

--- a/docs/data/Either/constructors/right.md
+++ b/docs/data/Either/constructors/right.md
@@ -1,0 +1,23 @@
+# `Either.<L, R>right(R value)`
+
+Encapsulates a right value.
+
+## Arguments
+
+* `value (R)`: A value.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(Either<L, R>)`: An `Either` of the `value`.
+
+## Example
+
+```java
+Either.<Integer, String>right("a");
+// => Right("a")
+```

--- a/docs/data/Either/instance/README.md
+++ b/docs/data/Either/instance/README.md
@@ -1,0 +1,8 @@
+# Either Instance Methods
+
+## Table of Contents
+
+* [`#equals`](./equals.md)
+* [`#isLeft`](./isLeft.md)
+* [`#isRight`](./isRight.md)
+* [`#toString`](./toString.md)

--- a/docs/data/Either/instance/equals.md
+++ b/docs/data/Either/instance/equals.md
@@ -1,0 +1,35 @@
+# `Either#<A, B>equals(Object other)`
+
+Determine whether or not the `other` has the same value as the current `instance`.
+
+## Arguments
+
+* `other (Object)`: The other object.
+
+## Types
+
+* `A`: The underlying left type.
+* `B`: The underlying right type.
+
+## Returns
+
+* `(boolean)`: `true` for equality; otherwise, `false`.
+
+## Examples
+
+```java
+const left = Either.<String, String>Left("a");
+const right = Either.<String, String>Right("a");
+
+right.equals("a");
+// => false
+
+right.equals(left);
+// => false
+
+right.equals(Either.<String, String>Right("a"));
+// => true
+
+left.equals(Either.<String, String>Left("a"));
+// => true
+```

--- a/docs/data/Either/instance/isLeft.md
+++ b/docs/data/Either/instance/isLeft.md
@@ -1,0 +1,22 @@
+# `Either#<A, B>isLeft()`
+
+Determines whether or not the `Either` is a `Left`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(boolean)`: `true` for a `Left`; otherwise, `false`.
+
+## Examples
+
+```java
+Either.<String, String>Left("a").isLeft();
+// => true
+
+Either.<String, String>Right("a").isLeft();
+// => false
+```

--- a/docs/data/Either/instance/isRight.md
+++ b/docs/data/Either/instance/isRight.md
@@ -1,0 +1,22 @@
+# `Either#<A, B>isRight()`
+
+Determines whether or not the `Either` is a `Right`.
+
+## Types
+
+* `A`: The underlying left type.
+* `B`: The underlying right type.
+
+## Returns
+
+* `(boolean)`: `true` for a `Right`; otherwise, `false`.
+
+## Examples
+
+```java
+Either.<String, String>Left("a").isRight();
+// => false
+
+Either.<String, String>Right("a").isRight();
+// => true
+```

--- a/docs/data/Either/instance/toString.md
+++ b/docs/data/Either/instance/toString.md
@@ -1,0 +1,22 @@
+# `Either#<A, B>toString()`
+
+Converts the `instance` to a `String` representation.
+
+## Types
+
+* `A`: The underlying left type.
+* `B`: The underlying right type.
+
+## Returns
+
+* `(String)`: The `instance` as a `String`.
+
+## Examples
+
+```java
+Either.Left("a").toString();
+// => "Left(a)"
+
+Either.Right("a").toString();
+// => "Right(a)"
+```

--- a/docs/data/Either/static/README.md
+++ b/docs/data/Either/static/README.md
@@ -1,0 +1,10 @@
+# Either Static Methods
+
+## Table of Contents
+
+* [`.eitherMap`](./eitherMap.md)
+* [`.fromLeft`](./fromLeft.md)
+* [`.fromRight`](./fromRight.md)
+* [`.lefts`](./lefts.md)
+* [`.partitionEithers`](./partitionEithers.md)
+* [`.rights`](./rights.md)

--- a/docs/data/Either/static/eitherMap.md
+++ b/docs/data/Either/static/eitherMap.md
@@ -1,0 +1,46 @@
+# `Either.<L, R, C>eitherMap(Function<L, C> leftMorphism, Function<R, C> rightMorphism, Either<L, R> either)`
+
+Provides a catamorphism of the `either` to a singular value. If the value is `Left a`, apply the first function to `a`; otherwise, apply the second function to `b`.
+
+## Alternatives
+
+* `Either.<L, R, C>eitherMap(Function<L, C> leftMorphism, Function<R, C> rightMorphism).apply(Either<L, R> either)`
+* `Either.<L, R, C>eitherMap(Function<L, C> leftMorphism).apply(Function<R, C> rightMorphism).apply(Either<L, R> either)`
+
+## Arguments
+
+* `leftMorphism (Function<L, C>)`: Maps the value of a `Left a` to `c`.
+* `rightMorphism (Function<R, C>)`: Maps the value of a `Right b` to `c`.
+* `either (Either<L, R>)`: The `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+* `C`: The return type.
+
+## Returns
+
+* `(C)`: The result of the catamorphism of the `either`.
+
+## Throws
+
+* `NullPointerException` if the `leftMorphism`, `rightMorphism`, or `either` is `null`.
+
+## Examples
+
+```java
+Either.eitherMap(
+  Exception::getMessage,
+  value -> String.format("The value is %s", value % 2 == 0 ? "even" : "odd"),
+  Either.right(1)
+);
+// => "The value is odd"
+
+Either.eitherMap(
+  Exception::getMessage,
+  value -> String.format("The value is %s", value % 2 == 0 ? "even" : "odd"),
+  Either.left(new RuntimeException("The value is not a number"))
+);
+// => "The value is not a number"
+```

--- a/docs/data/Either/static/fromLeft.md
+++ b/docs/data/Either/static/fromLeft.md
@@ -1,0 +1,32 @@
+# `Either.<L, R>fromLeft(L defaultValue, Either<L, R> either)`
+
+Extracts the value out of a `Left`; otherwise, returns the `defaultValue`.
+
+## Alternatives
+
+* `Either.<L, R>fromLeft(L defaultValue).apply(Either<L, R> either)`
+
+## Arguments
+
+* `defaultValue (L)`: Value used if the `either` is not a `Left`.
+* `either (Either<L, R>)`: The `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(L)`: The underlying left value.
+
+## Examples
+
+```java
+Either.fromLeft(0, Either.<Integer, String>Left(1));
+// => 1
+
+Either.<Integer, String>fromLeft(0)
+  .apply(Either.<Integer, String>Right("a"));
+// => 0
+```

--- a/docs/data/Either/static/fromRight.md
+++ b/docs/data/Either/static/fromRight.md
@@ -1,0 +1,32 @@
+# `Either.<L, R>fromRight(R defaultValue, Either<L, R> either)`
+
+Extracts the value out of a `Right`; otherwise, returns the `defaultValue`.
+
+## Alternatives
+
+* `Either.<L, R>fromRight(R defaultValue).apply(Either<L, R> either)`
+
+## Arguments
+
+* `defaultValue (R)`: Value used if the `either` is not a `Right`.
+* `either (Either<L, R>)`: The `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(R)`: The underlying right value or default.
+
+## Examples
+
+```java
+Either.fromRight(0, Either.<String, Integer>Right(1));
+// => 1
+
+Either.<String, Integer>fromRight(0)
+  .apply(Either.<String, Integer>Left("a"));
+// => 0
+```

--- a/docs/data/Either/static/lefts.md
+++ b/docs/data/Either/static/lefts.md
@@ -1,0 +1,28 @@
+# `Either.<L, R>lefts(Collection<Either<L, R>> collection)`
+
+Extracts from a collection of `Either` all of the `Left` elements in extracted order.
+
+## Arguments
+
+* `collection (Collection<Either<L, R>>)` - The collection of `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(Collection<L>)`: The collection of underlying `Left` values.
+
+## Examples
+
+```java
+Either.lefts(Arrays.asList(
+  Either.left("a"),
+  Either.left("b"),
+  Either.right(0),
+  Either.right(1)
+));
+// => ["a", "b"]
+```

--- a/docs/data/Either/static/partitionEithers.md
+++ b/docs/data/Either/static/partitionEithers.md
@@ -1,0 +1,28 @@
+# `Either.<L, R>partitionEithers(Collection<Either<L, R>> collection)`
+
+Partitions a collection of `Either` into two collections. All `Left` elements are extracted, in order, to the first position of the output. Similarly for the `Right` elements in the second position.
+
+## Arguments
+
+* `collection (Collection<Either<L, R>>)` - The collection of `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(Tuple<Collection<L>, Collection<R>>)`: A couple of a collection of the underlying `Left` values and a collection of the underlying `Right` values.
+
+## Examples
+
+```java
+Either.partitionEithers(Arrays.asList(
+  Either.left("a"),
+  Either.left("b"),
+  Either.right(0),
+  Either.right(1)
+));
+// => Tuple(["a", "b"], [0, 1])
+```

--- a/docs/data/Either/static/rights.md
+++ b/docs/data/Either/static/rights.md
@@ -1,0 +1,28 @@
+# `Either.<L, R>rights(Collection<Either<L, R>> collection)`
+
+Extracts from a collection of `Either` all of the `Right` elements in extracted order.
+
+## Arguments
+
+* `collection (Collection<Either<L, R>>)` - The collection of `Either`.
+
+## Types
+
+* `L`: The underlying left type.
+* `R`: The underlying right type.
+
+## Returns
+
+* `(Collection<R>)`: The collection of underlying `Right` values.
+
+## Examples
+
+```java
+Either.rights(Arrays.asList(
+  Either.left("a"),
+  Either.left("b"),
+  Either.right(0),
+  Either.right(1)
+));
+// => [0, 1]
+```

--- a/docs/data/Maybe/instance/equals.md
+++ b/docs/data/Maybe/instance/equals.md
@@ -1,4 +1,4 @@
-# `Maybe<A>#equals(Object other)`
+# `Maybe#<A>equals(Object other)`
 
 Determine whether or not the `other` has the same value as the current `instance`.
 

--- a/docs/data/Maybe/instance/hashCode.md
+++ b/docs/data/Maybe/instance/hashCode.md
@@ -1,4 +1,4 @@
-# `Maybe<A>#hashCode()`
+# `Maybe#<A>hashCode()`
 
 Generates a hash code representing the underlying values of the `Maybe`.
 

--- a/docs/data/Maybe/instance/isJust.md
+++ b/docs/data/Maybe/instance/isJust.md
@@ -1,4 +1,4 @@
-# `Maybe<A>#isJust()`
+# `Maybe#<A>isJust()`
 
 Determines whether or not the `Maybe` is a `Just`.
 

--- a/docs/data/Maybe/instance/isNothing.md
+++ b/docs/data/Maybe/instance/isNothing.md
@@ -1,4 +1,4 @@
-# `Maybe<A>#isNothing()`
+# `Maybe#<A>isNothing()`
 
 Determines whether or not the `Maybe` is a `Nothing`.
 

--- a/docs/data/Maybe/instance/toString.md
+++ b/docs/data/Maybe/instance/toString.md
@@ -1,4 +1,4 @@
-# `Maybe<A>#toString()`
+# `Maybe#<A>toString()`
 
 Converts the `instance` to a `String` representation.
 

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -2,6 +2,19 @@
 
 ## Table of Contents
 
+* [`Either`](./Either)
+    * [`.left`](./Either/constructors/left.md)
+    * [`.right`](./Either/constructors/right.md)
+    * [`.eitherMap`](./Either/static/eitherMap.md)
+    * [`.fromLeft`](./Either/static/fromLeft.md)
+    * [`.fromRight`](./Either/static/fromRight.md)
+    * [`.lefts`](./Either/static/lefts.md)
+    * [`.partitionEithers`](./Either/static/partitionEithers.md)
+    * [`.rights`](./Either/static/rights.md)
+    * [`#equals`](./Either/instance/equals.md)
+    * [`#isLeft`](./Either/instance/isLeft.md)
+    * [`#isRight`](./Either/instance/isRight.md)
+    * [`#toString`](./Either/instance/toString.md)
 * [`Functions`](./Functions)
     * [`.compose`](./Functions/compose.md)
     * [`.const`](./Functions/const.md)

--- a/src/main/java/com/github/jlmorgan/data/Either.java
+++ b/src/main/java/com/github/jlmorgan/data/Either.java
@@ -1,0 +1,327 @@
+package com.github.jlmorgan.data;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The {@link Either} type is a right-biased disjunction that represents two possibilities: either a {@code Left} of
+ * {@code a} or a {@code Right} of {@code b}. By convention, the {@link Either} is used to represent a value or an
+ * error result of some function or process as a {@code Left} of the error or a {@code Right} of the value.
+ * @param <A> The underlying left type.
+ * @param <B> The underlying right type.
+ */
+public interface Either<A, B> {
+  /**
+   * Curried implementation of {@link Either#eitherMap(Function, Function, Either)}.
+   */
+  @NotNull
+  @Contract(pure = true)
+  static <L, R, C> Function<Function<R, C>, Function<Either<L, R>, C>> eitherMap(
+    final Function<? super L, ? extends C> leftMorphism
+  ) {
+    return rightMorphism -> eitherMap(leftMorphism, rightMorphism);
+  }
+
+  /**
+   * Partially curried implementation of {@link Either#eitherMap(Function, Function, Either)}.
+   */
+  @NotNull
+  @Contract(pure = true)
+  static <L, R, C> Function<Either<L, R>, C> eitherMap(
+    final Function<? super L, ? extends C> leftMorphism,
+    final Function<? super R, ? extends C> rightMorphism
+  ) {
+    return either -> eitherMap(leftMorphism, rightMorphism, either);
+  }
+
+  /**
+   * Provides a catamorphism of the {@code either} to a singular value. If the value is {@code Left t}, apply the first
+   * function to {@code t}; otherwise, apply the second function to {@code u}.
+   * @param leftMorphism Maps the value of a {@code Left t} to {@code c}.
+   * @param rightMorphism Maps the value of a {@code Right u} to {@code c}.
+   * @param either The {@link Either}.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @param <C> The return type.
+   * @return The result of the catamorphism of the {@code either}.
+   * @see <a href="https://en.wikipedia.org/wiki/Catamorphism">Catamorphism</a>
+   * @throws NullPointerException if the {@code leftMorphism}, {@code rightMorphism}, or {@code either} is {@code null}.
+   */
+  static <L, R, C> C eitherMap(
+    final Function<? super L, ? extends C> leftMorphism,
+    final Function<? super R, ? extends C> rightMorphism,
+    final Either<L, R> either
+  ) {
+    return requireNonNull(either, "either must not be null").isRight()
+      ? requireNonNull(rightMorphism, "rightMorphism must not be null").apply(fromRight(null, either))
+      : requireNonNull(leftMorphism, "leftMorphism must not be null").apply(fromLeft(null, either));
+  }
+
+  /**
+   * Curried implementation of {@link Either#fromLeft(Object, Either)}.
+   */
+  @NotNull
+  @Contract(pure = true)
+  static <L, R> Function<Either<L, R>, L> fromLeft(final L defaultValue) {
+    return either -> fromLeft(defaultValue, either);
+  }
+
+  /**
+   * Extracts the value of a {@code Left}; otherwise, returns the {@code defaultValue}.
+   * @param defaultValue Value used if the {@code either} is not a {@code Left}.
+   * @param either The {@link Either}.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @return The underlying left value or the default.
+   */
+  @Contract("_, null -> param1")
+  static <L, R> L fromLeft(final L defaultValue, final Either<L, R> either) {
+    return either == null || either.isRight()
+      ? defaultValue
+      : ((Left<L, R>) either)._value;
+  }
+
+  /**
+   * Curried implementation of {@link Either#fromRight(Object, Either)}.
+   */
+  @NotNull
+  @Contract(pure = true)
+  static <L, R> Function<Either<L, R>, R> fromRight(final R defaultValue) {
+    return either -> fromRight(defaultValue, either);
+  }
+
+  /**
+   * Extracts the value of a {@code Right}; otherwise, returns the {@code defaultValue}.
+   * @param defaultValue Value used if the {@code either} is not a {@code Right}.
+   * @param either The {@link Either}.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @return The underlying right value or the default.
+   */
+  @Contract("_, null -> param1")
+  static <L, R> R fromRight(final R defaultValue, final Either<L, R> either) {
+    return either == null || either.isLeft()
+      ? defaultValue
+      : ((Right<L, R>) either)._value;
+  }
+
+  /**
+   * Creates a {@code Left} from an arbitrary value.
+   * @param value The value.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @return A {@code Left} of the value.
+   */
+  @NotNull
+  @Contract(value = "_ -> new", pure = true)
+  static <L, R> Either<L, R> left(final L value) {
+    return new Left<>(value);
+  }
+
+  /**
+   * Extracts from a collection of {@link Either} all of the {@code Left} elements in extracted order.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @param collection The collection of {@link Either}.
+   * @return The collection of underlying {@code Left} values.
+   */
+  static <L, R> Collection<L> lefts(final Collection<Either<L, R>> collection) {
+    return Optional.ofNullable(collection)
+      .map(Collection::stream)
+      .orElseGet(Stream::empty)
+      .filter(Objects::nonNull)
+      .filter(Either::isLeft)
+      .map(fromLeft(null))
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * Partitions a collection of {@link Either} into two lists. All {@code Left} elements are extracted, in order, to the
+   * first position of the output. Similarly for the {@code Right} elements in the second position.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @param collection The collection of {@link Either}.
+   * @return A couple of a collection of the underlying {@code Left} values and a collection of the underlying
+   * {@code Right} values.
+   */
+  @NotNull
+  static <L, R> Tuple<Collection<L>, Collection<R>> partitionEithers(final Collection<Either<L, R>> collection) {
+    return Tuple.of(lefts(collection), rights(collection));
+  }
+
+  /**
+   * Creates a {@code Right} from an arbitrary value.
+   * @param value The value.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @return A {@code Right} of the value.
+   */
+  @NotNull
+  @Contract(value = "_ -> new", pure = true)
+  static <L, R> Either<L, R> right(final R value) {
+    return new Right<>(value);
+  }
+
+  /**
+   * Extracts from a collection of {@link Either} all of the {@code Right} elements in extracted order.
+   * @param <L> The underlying left type.
+   * @param <R> The underlying right type.
+   * @param collection The collection of {@link Either}.
+   * @return The collection of underlying {@code Right} values.
+   */
+  static <L, R> List<R> rights(final Collection<Either<L, R>> collection) {
+    return Optional.ofNullable(collection)
+      .map(Collection::stream)
+      .orElseGet(Stream::empty)
+      .filter(Objects::nonNull)
+      .filter(Either::isRight)
+      .map(fromRight(null))
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * Determines whether or not the instance is a {@code Right}.
+   * @return {@code true} for a {@code Right}; otherwise, {@code false}.
+   */
+  boolean isRight();
+
+  /**
+   * Determines whether or not the instance is a {@code Left}.
+   * @return {@code true} for a {@code Left}; otherwise, {@code false}.
+   */
+  default boolean isLeft() {
+    return !isRight();
+  }
+
+  /**
+   * Encapsulates the left value of the disjunction.
+   * @param <A> The underlying left type.
+   * @param <B> The underlying right type.
+   */
+  class Left<A, B> implements Either<A, B> {
+    private final A _value;
+
+    Left(final A value) {
+      _value = value;
+    }
+
+    /**
+     * Determine whether or not the {@code other} has the same value as the current {@code instance}.
+     * @param other The other object.
+     * @return {@code true} for equality; otherwise, {@code false}.
+     */
+    @Contract(value = "null -> false", pure = true)
+    @Override
+    public boolean equals(final Object other) {
+      boolean result = false;
+
+      if (this == other) {
+        result = true;
+      } else if (other != null && getClass() == other.getClass()) {
+        final Left<?, ?> left = (Left<?, ?>) other;
+
+        result = _value.equals(left._value);
+      }
+
+      return result;
+    }
+
+    /**
+     * Generates a hash code representing the underlying values of the {@link Either}.
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(_value);
+    }
+
+    /**
+     * Determines whether or not the instance is a {@code Right}.
+     * @return {@code true} for a {@code Right}; otherwise, {@code false}.
+     */
+    @Override
+    public boolean isRight() {
+      return false;
+    }
+
+    /**
+     * Converts the {@code instance} to a {@link String} representation.
+     * @return The {@code instance} as a {@link String}.
+     */
+    @Override
+    public String toString() {
+      return String.format("Left(%s)", _value);
+    }
+  }
+
+  /**
+   * Encapsulates the right value of the disjunction.
+   * @param <A> The underlying left type.
+   * @param <B> The underlying right type.
+   */
+  class Right<A, B> implements Either<A, B> {
+    private final B _value;
+
+    Right(final B value) {
+      _value = value;
+    }
+
+    /**
+     * Determine whether or not the {@code other} has the same value as the current {@code instance}.
+     * @param other The other object.
+     * @return {@code true} for equality; otherwise, {@code false}.
+     */
+    @Contract(value = "null -> false", pure = true)
+    @Override
+    public boolean equals(final Object other) {
+      boolean result = false;
+
+      if (this == other) {
+        result = true;
+      } else if (other != null && getClass() == other.getClass()) {
+        final Right<?, ?> right = (Right<?, ?>) other;
+
+        result = _value.equals(right._value);
+      }
+
+      return result;
+    }
+
+    /**
+     * Generates a hash code representing the underlying values of the {@link Either}.
+     * @return The hash code.
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hash(_value);
+    }
+
+    /**
+     * Determines whether or not the instance is a {@code Right}.
+     * @return {@code true} for a {@code Right}; otherwise, {@code false}.
+     */
+    @Override
+    public boolean isRight() {
+      return true;
+    }
+
+    /**
+     * Converts the {@code instance} to a {@link String} representation.
+     * @return The {@code instance} as a {@link String}.
+     */
+    @Override
+    public String toString() {
+      return String.format("Right(%s)", _value);
+    }
+  }
+}

--- a/src/main/java/com/github/jlmorgan/data/Maybe.java
+++ b/src/main/java/com/github/jlmorgan/data/Maybe.java
@@ -43,7 +43,7 @@ public interface Maybe<A> {
     return Optional.ofNullable(maybe)
       .filter(Maybe::isJust)
       .map(just -> ((Just<V>) just)._value)
-      .orElseThrow(() -> new IllegalArgumentException("maybeMap must not be null or Nothing"));
+      .orElseThrow(() -> new IllegalArgumentException("maybe must not be null or Nothing"));
   }
 
   /**
@@ -138,7 +138,7 @@ public interface Maybe<A> {
   @NotNull
   @Contract(pure = true)
   static <V, R> Function<Function<V, R>, Function<Maybe<V>, R>> maybeMap(final R defaultValue) {
-    return morphism -> instance -> maybeMap(defaultValue, morphism).apply(instance);
+    return morphism -> maybeMap(defaultValue, morphism);
   }
 
   /**

--- a/src/test/java/com/github/jlmorgan/data/EitherTests.java
+++ b/src/test/java/com/github/jlmorgan/data/EitherTests.java
@@ -1,0 +1,511 @@
+package com.github.jlmorgan.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Either")
+class EitherTests {
+  @Nested
+  class DescribeStaticMethods {
+    @Nested
+    class DescribeEitherMap {
+      private final Function<RuntimeException, String> _testLeftMorphism = RuntimeException::getMessage;
+      private final Function<UUID, String> _testRightMorphism = UUID::toString;
+
+      @Test
+      void shouldThrowExceptionForNullLeftMorphism() {
+        final Function<RuntimeException, String> testLeftMorphism = null;
+        final Either<RuntimeException, UUID> testEither = Either.right(null);
+
+        assertThrows(
+          NullPointerException.class,
+          () -> Either.<RuntimeException, UUID, String>eitherMap(testLeftMorphism)
+            .apply(_testRightMorphism)
+            .apply(testEither)
+        );
+      }
+
+      @Test
+      void shouldThrowExceptionForNullRightMorphism() {
+        final Function<UUID, String> testRightMorphism = null;
+        final Either<RuntimeException, UUID> testEither = Either.right(null);
+
+        assertThrows(
+          NullPointerException.class,
+          () -> Either.<RuntimeException, UUID, String>eitherMap(_testLeftMorphism)
+            .apply(testRightMorphism)
+            .apply(testEither)
+        );
+      }
+
+      @Test
+      void shouldThrowExceptionForNullEither() {
+        final Either<RuntimeException, UUID> testEither = null;
+
+        assertThrows(
+          NullPointerException.class,
+          () -> Either.<RuntimeException, UUID, String>eitherMap(_testLeftMorphism)
+            .apply(_testRightMorphism)
+            .apply(testEither)
+        );
+      }
+
+      @Test
+      void shouldReturnMappedValueForLeft() {
+        final RuntimeException testLeftValue = new RuntimeException(UUID.randomUUID().toString());
+        final Either<RuntimeException, UUID> testEither = Either.left(testLeftValue);
+        final String expectedResult = testLeftValue.getMessage();
+        final String actualResult = Either.eitherMap(_testLeftMorphism, _testRightMorphism).apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnMappedValueForRight() {
+        final UUID testRightValue = UUID.randomUUID();
+        final Either<RuntimeException, UUID> testEither = Either.right(testRightValue);
+        final String expectedResult = testRightValue.toString();
+        final String actualResult = Either.eitherMap(_testLeftMorphism, _testRightMorphism, testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+
+    @Nested
+    class DescribeFromLeft {
+      private final RuntimeException _testDefaultValue = new RuntimeException(UUID.randomUUID().toString());
+
+      @Test
+      void shouldReturnDefaultValueForNull() {
+        final Either<RuntimeException, UUID> testEither = null;
+        // noinspection UnnecessaryLocalVariable
+        final RuntimeException expectedResult = _testDefaultValue;
+        // noinspection ConstantConditions
+        final RuntimeException actualResult = Either.<RuntimeException, UUID>fromLeft(_testDefaultValue)
+          .apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnDefaultValueForRight() {
+        final Either<RuntimeException, UUID> testEither = Either.right(null);
+        // noinspection UnnecessaryLocalVariable
+        final RuntimeException expectedResult = _testDefaultValue;
+        final RuntimeException actualResult = Either.<RuntimeException, UUID>fromLeft(_testDefaultValue)
+          .apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnValueForLeft() {
+        final RuntimeException testLeftValue = new RuntimeException(UUID.randomUUID().toString());
+        final Either<RuntimeException, UUID> testEither = Either.left(testLeftValue);
+        // noinspection UnnecessaryLocalVariable
+        final RuntimeException expectedResult = testLeftValue;
+        final RuntimeException actualResult = Either.<RuntimeException, UUID>fromLeft(_testDefaultValue)
+          .apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+
+    @Nested
+    class DescribeFromRight {
+      private final UUID _testDefaultValue = UUID.randomUUID();
+
+      @Test
+      void shouldReturnDefaultValueForNull() {
+        final Either<RuntimeException, UUID> testEither = null;
+        // noinspection UnnecessaryLocalVariable
+        final UUID expectedResult = _testDefaultValue;
+        // noinspection ConstantConditions
+        final UUID actualResult = Either.<RuntimeException, UUID>fromRight(_testDefaultValue).apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+
+        Either.lefts(Arrays.asList(
+          Either.left("a"),
+          Either.left("b"),
+          Either.right(0),
+          Either.right(1)
+        ));
+      }
+
+      @Test
+      void shouldReturnDefaultValueForRight() {
+        final Either<RuntimeException, UUID> testEither = Either.left(null);
+        // noinspection UnnecessaryLocalVariable
+        final UUID expectedResult = _testDefaultValue;
+        final UUID actualResult = Either.<RuntimeException, UUID>fromRight(_testDefaultValue).apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnValueForRight() {
+        final UUID testRightValue = UUID.randomUUID();
+        final Either<RuntimeException, UUID> testEither = Either.right(testRightValue);
+        // noinspection UnnecessaryLocalVariable
+        final UUID expectedResult = testRightValue;
+        final UUID actualResult = Either.<RuntimeException, UUID>fromRight(_testDefaultValue).apply(testEither);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+
+    @Nested
+    class DescribeLefts {
+      @Test
+      void shouldReturnEmptyListForNullCollection() {
+        final Collection<Either<String, UUID>> testList = null;
+        final Collection<String> expectedResult = Collections.emptyList();
+        // noinspection ConstantConditions
+        final Collection<String> actualResult = Either.lefts(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListForEmptyCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.emptyList();
+        final Collection<String> expectedResult = Collections.emptyList();
+        final Collection<String> actualResult = Either.lefts(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListForBlankCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.singletonList(null);
+        final Collection<String> expectedResult = Collections.emptyList();
+        final Collection<String> actualResult = Either.lefts(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnListOfLeftValuesForMixedCollection() {
+        final String testLeftValue1 = UUID.randomUUID().toString();
+        final String testLeftValue2 = UUID.randomUUID().toString();
+        final UUID testRightValue1 = UUID.randomUUID();
+        final UUID testRightValue2 = UUID.randomUUID();
+        final Collection<Either<String, UUID>> testList = Arrays.asList(
+          Either.left(testLeftValue1),
+          Either.left(testLeftValue2),
+          Either.right(testRightValue1),
+          Either.right(testRightValue2)
+        );
+        final Collection<String> expectedResult = Arrays.asList(
+          testLeftValue1,
+          testLeftValue2
+        );
+        final Collection<String> actualResult = Either.lefts(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+
+    @Nested
+    class DescribePartitionEithers {
+      @Test
+      void shouldReturnEmptyListsForNullCollection() {
+        final Collection<Either<String, UUID>> testList = null;
+        final Tuple<Collection<String>, Collection<UUID>> expectedResult = Tuple.of(
+          Collections.emptyList(),
+          Collections.emptyList()
+        );
+        // noinspection ConstantConditions
+        final Tuple<Collection<String>, Collection<UUID>> actualResult = Either.partitionEithers(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListsForEmptyCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.emptyList();
+        final Tuple<Collection<String>, Collection<UUID>> expectedResult = Tuple.of(
+          Collections.emptyList(),
+          Collections.emptyList()
+        );
+        final Tuple<Collection<String>, Collection<UUID>> actualResult = Either.partitionEithers(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListsForBlankCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.singletonList(null);
+        final Tuple<Collection<String>, Collection<UUID>> expectedResult = Tuple.of(
+          Collections.emptyList(),
+          Collections.emptyList()
+        );
+        final Tuple<Collection<String>, Collection<UUID>> actualResult = Either.partitionEithers(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnPartitionedListsForMixedCollection() {
+        final String testLeftValue1 = UUID.randomUUID().toString();
+        final String testLeftValue2 = UUID.randomUUID().toString();
+        final UUID testRightValue1 = UUID.randomUUID();
+        final UUID testRightValue2 = UUID.randomUUID();
+        final Collection<Either<String, UUID>> testList = Arrays.asList(
+          Either.left(testLeftValue1),
+          Either.left(testLeftValue2),
+          Either.right(testRightValue1),
+          Either.right(testRightValue2)
+        );
+        final Tuple<Collection<String>, Collection<UUID>> expectedResult = Tuple.of(
+          Arrays.asList(testLeftValue1, testLeftValue2),
+          Arrays.asList(testRightValue1, testRightValue2)
+        );
+        final Tuple<Collection<String>, Collection<UUID>> actualResult = Either.partitionEithers(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+
+    @Nested
+    class DescribeRights {
+      @Test
+      void shouldReturnEmptyListForNullCollection() {
+        final Collection<Either<String, UUID>> testList = null;
+        final Collection<UUID> expectedResult = Collections.emptyList();
+        // noinspection ConstantConditions
+        final Collection<UUID> actualResult = Either.rights(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListForEmptyCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.emptyList();
+        final Collection<UUID> expectedResult = Collections.emptyList();
+        final Collection<UUID> actualResult = Either.rights(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnEmptyListForBlankCollection() {
+        final Collection<Either<String, UUID>> testList = Collections.singletonList(null);
+        final Collection<UUID> expectedResult = Collections.emptyList();
+        final Collection<UUID> actualResult = Either.rights(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+
+      @Test
+      void shouldReturnListOfLeftValuesForMixedCollection() {
+        final String testLeftValue1 = UUID.randomUUID().toString();
+        final String testLeftValue2 = UUID.randomUUID().toString();
+        final UUID testRightValue1 = UUID.randomUUID();
+        final UUID testRightValue2 = UUID.randomUUID();
+        final Collection<Either<String, UUID>> testList = Arrays.asList(
+          Either.left(testLeftValue1),
+          Either.left(testLeftValue2),
+          Either.right(testRightValue1),
+          Either.right(testRightValue2)
+        );
+        final Collection<UUID> expectedResult = Arrays.asList(
+          testRightValue1,
+          testRightValue2
+        );
+        final Collection<UUID> actualResult = Either.rights(testList);
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+  }
+
+  @Nested
+  class DescribeLeft {
+    private final String _testLeftValue = UUID.randomUUID().toString();
+    private final Either<String, UUID> _testEither = Either.left(_testLeftValue);
+
+    @Nested
+    class DescribeEquals {
+      @Test
+      void shouldReturnFalseForNull() {
+        final Either<String, UUID> testOther = null;
+
+        // noinspection ConstantConditions, SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnFalseForDifferingType() {
+        final Object testOther = new Object();
+
+        // noinspection SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnFalseForDifferingValues() {
+        final Either<String, UUID> testOther = Either.left(UUID.randomUUID().toString());
+
+        // noinspection SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnTrueForSameInstance() {
+        // noinspection EqualsWithItself, SimplifiableJUnitAssertion
+        assertTrue(_testEither.equals(_testEither));
+      }
+
+      @Test
+      void shouldReturnTrueForSameValue() {
+        final Either<String, UUID> testOther = Either.left(_testLeftValue);
+
+        // noinspection SimplifiableJUnitAssertion
+        assertTrue(_testEither.equals(testOther));
+      }
+    }
+
+    @Nested
+    class DescribeHashCode {
+      @Test
+      void shouldReturnDifferingHashCodeForDifferingValues() {
+        final Either<String, UUID> testOther = Either.left(UUID.randomUUID().toString());
+
+        assertNotEquals(_testEither.hashCode(), testOther.hashCode());
+      }
+
+      @Test
+      void shouldReturnSameHashCodeForSameValues() {
+        final Either<String, UUID> testOther = Either.left(_testLeftValue);
+
+        assertEquals(_testEither.hashCode(), testOther.hashCode());
+      }
+    }
+
+    @Nested
+    class DescribeIsLeft {
+      @Test
+      void shouldReturnTrue() {
+        assertTrue(_testEither.isLeft());
+      }
+    }
+
+    @Nested
+    class DescribeIsRight {
+      @Test
+      void shouldReturnFalse() {
+        assertFalse(_testEither.isRight());
+      }
+    }
+
+    @Nested
+    class DescribeToString {
+      @Test
+      void shouldReturnFormattedString() {
+        final String expectedResult = String.format("Left(%s)", _testLeftValue);
+        final String actualResult = _testEither.toString();
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+  }
+
+  @Nested
+  class DescribeRight {
+    private final UUID _testRightValue = UUID.randomUUID();
+    private final Either<String, UUID> _testEither = Either.right(_testRightValue);
+
+    @Nested
+    class DescribeEquals {
+      @Test
+      void shouldReturnFalseForNull() {
+        final Either<String, UUID> testOther = null;
+
+        // noinspection ConstantConditions, SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnFalseForDifferingType() {
+        final Object testOther = new Object();
+
+        // noinspection SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnFalseForDifferingValues() {
+        final Either<String, UUID> testOther = Either.right(UUID.randomUUID());
+
+        // noinspection SimplifiableJUnitAssertion
+        assertFalse(_testEither.equals(testOther));
+      }
+
+      @Test
+      void shouldReturnTrueForSameInstance() {
+        // noinspection EqualsWithItself, SimplifiableJUnitAssertion
+        assertTrue(_testEither.equals(_testEither));
+      }
+
+      @Test
+      void shouldReturnTrueForSameValue() {
+        final Either<String, UUID> testOther = Either.right(_testRightValue);
+
+        // noinspection SimplifiableJUnitAssertion
+        assertTrue(_testEither.equals(testOther));
+      }
+    }
+
+    @Nested
+    class DescribeHashCode {
+      @Test
+      void shouldReturnDifferingHashCodeForDifferingValues() {
+        final Either<String, UUID> testEither2 = Either.right(UUID.randomUUID());
+
+        assertNotEquals(_testEither.hashCode(), testEither2.hashCode());
+      }
+
+      @Test
+      void shouldReturnSameHashCodeForSameValues() {
+        final Either<String, UUID> testEither2 = Either.right(_testRightValue);
+
+        assertEquals(_testEither.hashCode(), testEither2.hashCode());
+      }
+    }
+
+    @Nested
+    class DescribeIsLeft {
+      @Test
+      void shouldReturnFalse() {
+        assertFalse(_testEither.isLeft());
+      }
+    }
+
+    @Nested
+    class DescribeIsRight {
+      @Test
+      void shouldReturnTrue() {
+        assertTrue(_testEither.isRight());
+      }
+    }
+
+    @Nested
+    class DescribeToString {
+      @Test
+      void shouldReturnFormattedString() {
+        final String expectedResult = String.format("Right(%s)", _testRightValue.toString());
+        final String actualResult = _testEither.toString();
+
+        assertEquals(expectedResult, actualResult);
+      }
+    }
+  }
+}

--- a/src/test/java/com/github/jlmorgan/data/MaybeTests.java
+++ b/src/test/java/com/github/jlmorgan/data/MaybeTests.java
@@ -348,16 +348,16 @@ class MaybeTests {
     class DescribeHashCode {
       @Test
       void shouldReturnDifferingHashCodeForDifferingValues() {
-        final Maybe<UUID> testMaybe2 = Maybe.just(UUID.randomUUID());
+        final Maybe<UUID> testOther = Maybe.just(UUID.randomUUID());
 
-        assertNotEquals(_testMaybe.hashCode(), testMaybe2.hashCode());
+        assertNotEquals(_testMaybe.hashCode(), testOther.hashCode());
       }
 
       @Test
       void shouldReturnSameHashCodeForSameValues() {
-        final Maybe<UUID> testMaybe2 = Maybe.just(_testValue);
+        final Maybe<UUID> testOther = Maybe.just(_testValue);
 
-        assertEquals(_testMaybe.hashCode(), testMaybe2.hashCode());
+        assertEquals(_testMaybe.hashCode(), testOther.hashCode());
       }
     }
 


### PR DESCRIPTION
- [x] Squash commits before merging.

* Fixed documented generic type declaration for Maybe#<A>equals.
* Fixed documented generic type declaration for Maybe#<A>hashCode.
* Fixed documented generic type declaration for Maybe#<A>isJust.
* Fixed documented generic type declaration for Maybe#<A>isNothing.
* Fixed documented generic type declaration for Maybe#<A>toString.
* Fixed exception message for Maybe.fromJust to refer to the correct context.
* Updated Maybe.<V, R>maybeMap(R) to call Maybe.<V, R>maybeMap(R, Function<V, R>).
* Updated MaybeTests/DescribeHashCode test variable names be consistent with similar tests.

closes #2
SemVer:Minor
enhancement